### PR TITLE
fixed priority sorting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -127,3 +127,10 @@ attribute on the response object::
             response['X-Renderer-Format'] = response.renderer.format
             return response 
 
+
+Testing
+-------
+
+From the root of the repository, run::
+
+    django-admin.py test --settings=django_conneg.test_settings --pythonpath=.

--- a/django_conneg/test_settings.py
+++ b/django_conneg/test_settings.py
@@ -1,0 +1,5 @@
+INSTALLED_APPS = (
+    'django_conneg',
+)
+
+TEST_RUNNER = 'django_conneg.tests.DatabaselessTestSuiteRunner'

--- a/django_conneg/tests.py
+++ b/django_conneg/tests.py
@@ -1,0 +1,71 @@
+import itertools
+import unittest
+
+from django.http import HttpResponse
+from django.test.simple import DjangoTestSuiteRunner
+
+from . import http, views, decorators
+
+class DatabaselessTestSuiteRunner(DjangoTestSuiteRunner):
+    def setup_databases(self, *args, **kwargs): pass
+    def teardown_databases(self, *args, **kwargs): pass
+
+class PriorityTestCase(unittest.TestCase):
+    mimetypes = ('text/plain', 'application/xml', 'text/html', 'application/json')
+
+    def getRenderer(self, format, mimetypes, name, priority):
+        if not isinstance(mimetypes, tuple):
+            mimetypes = (mimetypes,)
+        def renderer(request, context, template_name):
+            return HttpResponse('', mimetype=mimetypes[0])
+        renderer.__name__ = 'render_%s' % mimetypes[0].replace('/', '_')
+        renderer = decorators.renderer(format=format,
+                                       mimetypes=mimetypes,
+                                       priority=priority)(renderer)
+        return renderer
+
+    def getTestView(self, priorities):
+        members = {}
+        for i, (mimetype, priority) in enumerate(priorities.items()):
+            members['render_%d' % i] = self.getRenderer(str(i), mimetype, str(i), priority)
+        TestView = type('TestView',
+                        (views.ContentNegotiatedView,),
+                        members)
+        return TestView
+
+    def testEqualQuality(self):
+        accept_header = ', '.join(self.mimetypes)
+        accept = views.ContentNegotiatedView.parse_accept_header(accept_header)
+
+        for mimetypes in itertools.permutations(self.mimetypes):
+            renderers = tuple(self.getRenderer(str(i), mimetype, str(i), -i) for i, mimetype in enumerate(mimetypes))
+
+            renderers = http.MediaType.resolve(accept, renderers)
+
+            for renderer, mimetype in zip(renderers, mimetypes):
+                self.assertEqual(iter(renderer.mimetypes).next(), http.MediaType(mimetype))
+
+    def testEqualQualityView(self):
+        accept_header = ', '.join(self.mimetypes)
+        accept = views.ContentNegotiatedView.parse_accept_header(accept_header)
+
+        for mimetypes in itertools.permutations(self.mimetypes):
+            priorities = dict((mimetype, -i) for i, mimetype in enumerate(mimetypes))
+            test_view = self.getTestView(priorities).as_view()
+            renderers = http.MediaType.resolve(accept, test_view._renderers)
+
+            for renderer, mimetype in zip(renderers, mimetypes):
+                self.assertEqual(iter(renderer.mimetypes).next(), http.MediaType(mimetype))
+
+    def testPrioritySorting(self):
+        for mimetypes in itertools.permutations(self.mimetypes):
+            priorities = dict((mimetype, -i) for i, mimetype in enumerate(mimetypes))
+            test_view = self.getTestView(priorities).as_view()
+
+            renderer_priorities = [renderer.priority for renderer in test_view._renderers]
+            self.assertSequenceEqual(renderer_priorities, sorted(renderer_priorities, reverse=True))
+
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
there was an attempt of sorting by group, but afaik that wasn't being used...
in any case, sorting in as_view wasn't working because get_renderers was getting them alphabetically sorted again.
should be working now, methinks...
