### PR TITLE
Add support for file extension-based content type overriding

### DIFF
--- a/django_conneg/views.py
+++ b/django_conneg/views.py
@@ -28,6 +28,7 @@ class BaseContentNegotiatedView(View):
     _default_format = None
     _force_fallback_format = None
     _format_override_parameter = 'format'
+    _format_override_extension = False
     
     template_name = None
 
@@ -70,6 +71,10 @@ class BaseContentNegotiatedView(View):
                 fallback_formats = (fallback_formats,)
             if request.REQUEST.get(self._format_override_parameter):
                 format_override = request.REQUEST[self._format_override_parameter].split(',')
+            elif self._format_override_extension and \
+                    request.path.rfind("/") < request.path.rfind("."):
+                _, format_override = request.path.rsplit(".", 1)
+                format_override = (str(format_override),)
             else:
                 format_override = None
             request.renderers = self.conneg.get_renderers(request=request,


### PR DESCRIPTION
Small patch to add support for checking the file extension of the request path and using that as an override (cf. using a request parameter like "format=json").

Support for this behaviour is switched on in the view class using a new class configuration variable "_format_override_extension", so there is no effect on existing users.

We use this to provide cleaner and more proxy-friendly URLs for our APIs: rather than:

http://api.example.com/foo/bar?format=json

this supports:

http://api.example.com/foo/bar.json
