### PR TITLE
Django 1.5+ compat

### DIFF
--- a/django_conneg/views.py
+++ b/django_conneg/views.py
@@ -300,7 +300,7 @@ class HTMLView(ContentNegotiatedView):
         try:
             return render_to_response(template_name,
                                       context, context_instance=RequestContext(request),
-                                      mimetype='text/html')
+                                      content_type='text/html')
         except TemplateDoesNotExist:
             return NotImplemented
 
@@ -313,7 +313,7 @@ class TextView(ContentNegotiatedView):
         try:
             return render_to_response(template_name,
                                       context, context_instance=RequestContext(request),
-                                      mimetype='text/plain')
+                                      content_type='text/plain')
         except TemplateDoesNotExist:
             return NotImplemented
 


### PR DESCRIPTION
What versions of Django should this module be supporting? found 1 change that raised an error with ox-it/django-webauth

kwargs to render_to_response have changed over the versions and mimetype became content_type:

https://docs.djangoproject.com/en/1.5/topics/http/shortcuts/#django.shortcuts.render_to_response
